### PR TITLE
cache the last submitted block in parentchain

### DIFF
--- a/backend/src/interfaces/output/blocksResponse.interface.ts
+++ b/backend/src/interfaces/output/blocksResponse.interface.ts
@@ -18,6 +18,7 @@ export interface BlockResponse extends BaseBlockResponse {
   parentHash: string;
   committedInSubnet: boolean;
   committedInParentChain: boolean;
+  submittedInParentChain: boolean;
 }
 
 export interface BaseBlockResponse {

--- a/backend/src/storage/block.ts
+++ b/backend/src/storage/block.ts
@@ -1,3 +1,4 @@
+import { SmartContractAuditedBlockInfo } from '../client/parentchain';
 import { MAX_NUM_OF_BLOCKS_IN_HISTORY } from '../config';
 import { Db } from './base';
 
@@ -5,8 +6,10 @@ const TYPE = 'BLOCK';
 // In case of no new blocks in 60s, we declare the block componenet of the system is not operational
 const STATUS_KEY = 'BLOCK_STATUS';
 const TTL = 60;
+const CHECK_PARENTCHAIN_TTL = 2;
 
 const LATEST_COMMITTEDBLOCK_KEY = 'LATEST_COMMITTED_BLOCK';
+const LATEST_PARENTCHAIN_SUBMITTED_KEY = 'LATEST_PARENTCHAIN_SUBMITTED_BLOCKINFO';
 
 /**
   This class is created so that we can easily swap with real DB without making changes to any other files.
@@ -57,6 +60,14 @@ export class BlockStorage {
 
   async getStatus(): Promise<boolean> {
     return this.db.get(STATUS_KEY) || false;
+  }
+
+  async getLastSubmittedBlockInfo(): Promise<SmartContractAuditedBlockInfo> {
+    return this.db.get(LATEST_PARENTCHAIN_SUBMITTED_KEY);
+  }
+
+  async setLastSubmittedToParentchainBlockInfo(blockInfo: SmartContractAuditedBlockInfo) {
+    this.db.set(LATEST_PARENTCHAIN_SUBMITTED_KEY, blockInfo, CHECK_PARENTCHAIN_TTL);
   }
 }
 

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -356,11 +356,15 @@ definitions:
         committedInParentChain:
           description: This boolean value is to indicate whether this block has been confirmed in the parent chain smart contract
           type: boolean
+        submittedInParentChain:
+          description: This boolean value is to indicate whether this block has been submitted in the parent chain smart contract and waiting for the confirmation
+          type: boolean
     required:
       - hash
       - number
       - committedInParentChain
       - committedInSubnet
+      - submittedInParentChain
         
 schemes:
  - https


### PR DESCRIPTION
I also added an extra value into the list of recent blocks: `submittedInParentChain` a boolean flag to indicate whether this block from subnet has been submitted into the parentchain. 